### PR TITLE
Add config & instructions for auto-launching on Steam Deck (and Linux distros with Systemd user instances)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,15 @@ if you're running either Windows or MacOS i cannot really give you any help with
 
 (if you do know a way to run this on startup on any of the mentioned systems, please create a pull request with an updated readme)
 
-however if you're running linux i do have a way to start the script on bootup.
+## Steam Deck / Linux with Systemd
+
+If you have a Steam Deck, it is possible to have steam-presence start automatically when your Steam Deck boots.  This method may also work on other Linux distributions that use per-used Systemd instances.  If you (as a regular user) can run the command `systemctl --user status` successfully, then this should work.
+
+The file `steam-presence.service` has more information and instructions.
+
+## Linux (not using Systemd)
+
+If you're running linux i do have a way to start the script on bootup.
 
 create a file named `startup.sh` and paste in the code below, changing the path so it finds the main.py file.
 

--- a/steam-presence.service
+++ b/steam-presence.service
@@ -34,6 +34,8 @@
 # * Launch the Konsole app to get a terminal.
 # * You'll be in your home directory.  Clone steam-presence from GitHub:
 #   > git clone https://github.com/JustTemmie/steam-presence.git
+# * Go into the recently downloaded directory
+#   > cd steam-presence
 # * Turn this Git clone into a Python venv:
 #   > python3.10 -m venv .
 # * Update the venv and install steam-presence required software

--- a/steam-presence.service
+++ b/steam-presence.service
@@ -1,0 +1,144 @@
+# This is a Systemd service file for steam-presence!
+# Using this, you can have steam-presence automatically start on Steam Deck,
+# even if you're using the Steam Deck in Gaming mode.
+
+# Systemd is a "system manager".  After the low-level OS starts up, Systemd is
+# responsible for running the programs that do things like connect you to the
+# network, start Bluetooth, and launch Steam.  It's also possible to have
+# Systemd handle other things, like automatically launching steam-presence!
+
+# This file contains the information that Systemd needs to know how to
+# launch steam-presence.  HOWEVER, Systemd is not smart enough to automatically
+# configure steam-presence.  So, before you can use this, you have to get
+# steam-presence working first.
+
+# WARNING: This is for advanced users only!  We can't really help you if things
+# go weird, because it is really hard to provide remote support.  Happily, none
+# of the things done here will modify the OS, so you're not going to damage your
+# Deck.
+
+# Here is what to do.  Remember, get Part 1 working before going to Part 2, etc.
+#
+# PART 1: Get and configure Discord
+# * On your Deck, go to Desktop mode.
+# * Launch the Discover app, search for, and install Discord.
+# * Launch Discord, and sign in.  Leave Discord running in the background.
+# * In the bottom-right of the screen, you'll see an icon for Steam.  Right-
+#   click it, and select "Library".
+# * Add a non-Steam game to your Library, and select Discord from the list of
+#   things you can add.  You'll now see Discord as a 'game'.  There won't be
+#   any logo in the Steam library, but that's OK.
+# * Minimize both Discord and Steam.  Don't exit them, just minimize them.
+#
+# PART 2: Get and configure steam-presence
+# * Launch the Konsole app to get a terminal.
+# * You'll be in your home directory.  Clone steam-presence from GitHub:
+#   > git clone https://github.com/JustTemmie/steam-presence.git
+# * Turn this Git clone into a Python venv:
+#   > python3.10 -m venv .
+# * Update the venv and install steam-presence required software
+#   > ./bin/python -m pip install --upgrade pip wheel
+#   > ./bin/python -m pip install -r requirements.txt
+# * Copy exampleconfig.json to config.json and edit it, as per the README.
+# * Run steam-presence.
+#   > ./bin/python ./main.py
+#   If everything is configured correctly, you should eventually be told
+#   "Everything is ready".
+#   Press Control-C to exit steam-presence.
+#
+# PART 3: Enable auto-start
+# * In the Konsole (the terminal), copy this file to the place where Systemd
+#   looks for service files:
+#   > cp steam-presence.service ~/.config/systemd/user/steam-presence.service
+# * Reload Systemd, so that is becomes aware of steam-presence:
+#   > systemctl --user daemon-reload
+# * Enable steam-presence, so that it will start automatically when the Steam
+#   Deck is restarted:
+#   > systemctl --user enable steam-presence
+# * Tell Systemd to start steam-presence:
+#   > systemctl --user start steam-presence
+# * Check on the status of steam-presence, to see if it started OK:
+#   > systemctl --user status steam-presence
+#   Systemd should tell you that steam-presence is running, and at the end
+#   of the output, you should see the "everything is ready" message.
+#   If the text goes off the right side of the screen, make the Konsole window
+#   larger and run the command again.
+#
+# PART 4: Test!
+# * Exit the terminal sesson:
+#   > exit
+# * On the Desktop, double-click the icon to "Return to Gaming Mode".
+# * Once in gaming mode, restart the Steam Deck.
+# * Once Steam Deck is rebooted, go to the Library, and launch Discord.
+# * Once Discord is running, press the STEAM button, go to the Library,
+#   and lanch an actual game.
+#   NOTE: It's important that you leave Discord running!  steam-presence
+#   uses Discord (which runs in the background) to relay status updates.
+# * Wait about a minute, and then go to Discord on another device (like your
+#   phone).  You should see that Discord is now showing the game you are
+#   playing!
+
+# Hopefully all of that worked!  Just remember:
+# * steam-presence will run in the background any time the Deck starts.
+#   If you want to reduce battery, you can disable it by going to Desktop mode,
+#   launching the Konsole app, and running these two commands:
+#   > systemctl --user stop steam-presence
+#   > systemctl --user disable steam-presence
+#   That will stop steam-presence, *and* keep it from starting again.
+#
+# * steam-presence needs Discord running in the background.
+#
+# * Always launch Discord *before* you launch a game.  That gives
+#   steam-presence time to wake up; also, when you've got multiple "games"
+#   running, Steam only says that you're "playing" the most recently-launched
+#   game.  So, if you launch Discord second, then Steam will tell everyone
+#   that you are "playing Discord".
+
+# Good luck!
+# The rest of this file is the actual contents of the Systemd service file.
+
+[Unit]
+# This is just basic information about what steam-presence is.
+Description=Discord rich presence from Steam on Linux
+Documentation=https://github.com/JustTemmie/steam-presence
+
+[Service]
+# CHANGEME: This is the full command that is run to launch steam-presence.
+# If you installed steam-presence somewhere else, then you need to change this.
+ExecStart=/home/deck/steam-presence/bin/python -u /home/deck/steam-presence/main.py
+
+# This tells Systemd that steam-presence is a simple service:
+# When launched, the Python process stays running until the service exits.
+Type=simple
+
+# This tells the OS to treat steam-presence as a lowest-priority program.
+Nice=19
+
+# When steam-presence is told to exit, it throws a KeyboardInterrupt Python
+# exception.  This tells Systemd that it's OK, and that should count as a
+# normal program exit.
+SuccessExitStatus=130
+
+# This locks down what steam-presence is able to do.  It is not able to
+# get any more privileges than it already has, and almost the entire
+# filesystem is made read-only to it.  The only thing made read/write is
+# the directory where steam-presence lives.  That is so the icons.txt file
+# can be updated with new game icons (only when you use SteamGridDB).
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/home/deck/steam-presence
+
+# This section is used when you run `systemctl --user enable steam-presence`.
+[Install]
+# WantedBy tells Systemd "when this service is enabled, it should be an
+# optional requirement of X".
+#
+# Normally, this is set to "multi-user.target".  In Systemd 'system mode',
+# where Systemd is managing services for the OS, "multi-user.target" is the
+# correct thing to use.  But because we are operating Systemd in 'user mode',
+# there is no "multi-user.target".  Instead, there is "default.target".
+#
+# Once the OS is up, Systemd starts up a user-mode instance for us, and looks
+# for any services that are "wanted by" the "default.target".  That is what
+# actually causes us to be launched at startup!
+WantedBy=default.target


### PR DESCRIPTION
I found a way to get steam-presence to automatically start up on my Steam Deck!

Turns out, since Steam Deck is based on Arch, and Arch has Systemd user instances, I was able to create a Systemd service file that can be run at the user level.  With this, and with a Python venv, there's no need for root access, and no need to change the OS file system.

This adds the **heavily**-commented systemd service file, and adds a mention to the README.

**NOTE:** This does work for me, but I would **really** appreciate if others could test this out!