### PR TITLE
remove specification of python version

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -62,7 +62,7 @@ cd "$HOME/steam-presence"
 echo "Executing commands in steam-presence directory..."
 
 # Execute commands in steam-presence directory
-python3.10 -m venv .
+python -m venv .
 ./bin/python -m pip install --upgrade pip wheel
 ./bin/python -m pip install -r requirements.txt
 

--- a/installer.sh
+++ b/installer.sh
@@ -62,7 +62,7 @@ cd "$HOME/steam-presence"
 echo "Executing commands in steam-presence directory..."
 
 # Execute commands in steam-presence directory
-python -m venv .
+python3 -m venv .
 ./bin/python -m pip install --upgrade pip wheel
 ./bin/python -m pip install -r requirements.txt
 


### PR DESCRIPTION
python2 doesn't exist anymore, so there is no need to specify the python version. python3.10 isn't the latest version anymore as well, so this can potentially lead to crashes, as the error code of generating `venv`  isn't checked.