### PR TITLE
Adds the ability for it to grab discord App IDs from an open source community managed App ID list

### DIFF
--- a/main.py
+++ b/main.py
@@ -587,6 +587,14 @@ def getGameDiscordID(loops=0):
     response = r.json()
     
     ignoredChars = "®©™℠"
+    try:
+        r = requests.get("https://raw.githubusercontent.com/superboo07/Open-source-Discord-AppIDs-for-Steam-Rich-Presence/main/customGameIDs.json")
+        listOfAppIDs = json.loads(r.text)
+        for i in listOfAppIDs:
+            response.append({
+                "name": i,
+                "id": listOfAppIDs[i]
+            })
     
     # check if the "customGameIDs.json" file exists, if so, open it
     if exists(f"{dirname(abspath(__file__))}/data/customGameIDs.json"):
@@ -595,20 +603,14 @@ def getGameDiscordID(loops=0):
             gameIDsFile = json.load(f)
             
             # load the values from the open source dictionary of app IDs
-            r = requests.get("https://raw.githubusercontent.com/superboo07/Open-source-Discord-AppIDs-for-Steam-Rich-Presence/main/customGameIDs.json")
-            listOfAppIDs = json.loads(r.text)
+
             # add the values from the file directly to the list returned by discord
             for i in gameIDsFile:
                 response.append({
                     "name": i,
                     "id": gameIDsFile[i]
                 })
-            
-            for i in listOfAppIDs:
-                response.append({
-                    "name": i,
-                    "id": listOfAppIDs[i]
-                })
+
     global appID
     
     # loop thru all games

--- a/main.py
+++ b/main.py
@@ -594,6 +594,9 @@ def getGameDiscordID(loops=0):
             # load the values of the file
             gameIDsFile = json.load(f)
             
+            # load the values from the open source dictionary of app IDs
+            r = requests.get("https://raw.githubusercontent.com/superboo07/Open-source-Discord-AppIDs-for-Steam-Rich-Presence/main/customGameIDs.json")
+            listOfAppIDs = json.loads(r.text)
             # add the values from the file directly to the list returned by discord
             for i in gameIDsFile:
                 response.append({
@@ -601,6 +604,11 @@ def getGameDiscordID(loops=0):
                     "id": gameIDsFile[i]
                 })
             
+            for i in listOfAppIDs:
+                response.append({
+                    "name": i,
+                    "id": listOfAppIDs[i]
+                })
     global appID
     
     # loop thru all games


### PR DESCRIPTION
You can find the dictionary of appIDs [here](https://github.com/superboo07/Open-source-Discord-AppIDs-for-Steam-Rich-Presence/tree/main), I'm hoping to expand it as time goes on to include more games that aren't on discords app ID list. I'll also be accepting any pull requests that go to it so people can submit their own app IDs. 