### PR TITLE
Implement a Blacklist for Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ the script will find:
  - [Disabling fetching steam's rich presence](#fetch-steam-rich-presence)
  - [Enabling steam reviews](#fetch-steam-reviews)
  - [Add a button to the steam store page](#add-steam-store-button)
+ - [Ability to blacklist games from showing up on discord rich presence](#blacklist) 
 
 you will still need to fill out the `STEAM_API_KEY` found [here](#steam-web-api) and the `USER_IDS` found [here](#user-ids)
 
@@ -172,7 +173,13 @@ this is what a full config file looks like; you only need to fill in the parts t
         "ENABLED": false,
         "URL": "https://raw.githubusercontent.com/JustTemmie/steam-presence/main/readmeimages/defaulticon.png",
         "TEXT": "Steam Presence on Discord"
-    }
+    },
+
+    "BLACKLIST": [
+    	"game1",
+    	"game2",
+    	"game3"
+    ]
 }
 ```
 # Steam web API
@@ -388,6 +395,20 @@ template:
     "Beaver Clicker": 1065249144853254245
 }
 ```
+
+# Blacklist
+
+Here you can add games that are not supposed to show up in Discord's rich presence. please fill in the games field according to the full name of the games, these are not case sensitive.
+
+Example:
+```
+"BLACKLIST" : [
+    "Hades",
+    "Deep Rock Galactic",
+    "Risk of Rain 2"
+]
+```
+
 
 # Python
 only tested on python3.8 and higher.

--- a/exampleconfig.json
+++ b/exampleconfig.json
@@ -39,5 +39,12 @@
         "ENABLED": false,
         "URL": "https://raw.githubusercontent.com/JustTemmie/steam-presence/main/readmeimages/defaulticon.png",
         "TEXT": "Steam Presence on Discord"
-    }
+    },
+
+    "BLACKLIST": [
+    	"game1",
+    	"game2",
+    	"game3"
+    ]
 }
+

--- a/main.py
+++ b/main.py
@@ -148,7 +148,13 @@ def getConfigFile():
             "ENABLED": False,
             "URL": "https://raw.githubusercontent.com/JustTemmie/steam-presence/main/readmeimages/defaulticon.png",
             "TEXT": "Steam Presence on Discord"
-        }
+        },
+  
+        "BLACKLIST" : [
+            "game1",
+            "game2",
+            "game3"
+        ]
     }
 
     if exists(f"{dirname(abspath(__file__))}/config.json"):
@@ -756,10 +762,20 @@ def getLocalPresence():
 def setPresenceDetails():
     global activeRichPresence
     global startTime
+    global currentGameBlacklisted
     
     details = None
     state = None
     buttons = None
+    
+    # ignore game if it is in blacklist, case insensitive check
+    if gameName.casefold() in map(str.casefold, blacklist):
+        if not currentGameBlacklisted:
+            log(f"{gameName} is in blacklist, not creating RPC object.")
+            currentGameBlacklisted = True
+        return
+    
+    currentGameBlacklisted = False
     
     # if the game ID is corresponding to "a game on steam" - set the details field to be the real game name
     if appID == defaultAppID or appID == defaultLocalAppID:
@@ -927,6 +943,9 @@ def main():
     global localGames
     global defaultAppID
     global defaultLocalAppID
+    global blacklist
+    global currentGameBlacklisted
+    currentGameBlacklisted = False
     
     global appID
     global startTime
@@ -962,6 +981,7 @@ def main():
     defaultLocalAppID = config["LOCAL_GAMES"]["LOCAL_DISCORD_APPLICATION_ID"]
     doLocalGames = config["LOCAL_GAMES"]["ENABLED"]
     localGames = config["LOCAL_GAMES"]["GAMES"]
+    blacklist = config["BLACKLIST"]
     
     steamStoreCoverartBackup = config["COVER_ART"]["USE_STEAM_STORE_FALLBACK"]
     gridEnabled = config["COVER_ART"]["STEAM_GRID_DB"]["ENABLED"]
@@ -1039,6 +1059,7 @@ def main():
         defaultLocalAppID = config["LOCAL_GAMES"]["LOCAL_DISCORD_APPLICATION_ID"]
         doLocalGames = config["LOCAL_GAMES"]["ENABLED"]
         localGames = config["LOCAL_GAMES"]["GAMES"]
+        blacklist = config["BLACKLIST"]
         
         steamStoreCoverartBackup = config["COVER_ART"]["USE_STEAM_STORE_FALLBACK"]
         gridEnabled = config["COVER_ART"]["STEAM_GRID_DB"]["ENABLED"]
@@ -1135,7 +1156,7 @@ def main():
                 
                 print("----------------------------------------------------------")
         
-        if activeRichPresence != gameRichPresence and isPlaying:
+        if activeRichPresence != gameRichPresence and isPlaying and not currentGameBlacklisted:
             setPresenceDetails()
             print("----------------------------------------------------------")
 


### PR DESCRIPTION
With Steam's new feature to [mark games as private](https://help.steampowered.com/en/faqs/view/1150-C06F-4D62-4966), it would be nice, if we can also hide specific games from Discord's RPC.

Blacklisted games can be set in the config.json file, and once a new RPC object is supposed to be created, it first checks if a game is in the blacklist, and ignores it if that's the case.

This is my first pull request, so I hope I haven't forgotten anything. But feel free to mention or edit any issues you have with it. :)