### PR TITLE
Use the exact same game icon as when playing it natively

### DIFF
--- a/main.py
+++ b/main.py
@@ -353,7 +353,7 @@ def getImageFromStorepage():
         respone = r.json()
         
         coverImage = respone[str(gameSteamID)]["data"]["header_image"]
-        coverImageText = f"{gameName}"
+        coverImageText = f"{gameName} on Steam"
         # do note this is NOT saved to disk, just in case someone ever adds an entry to the SGDB later on
         
         log(f"successfully found steam's icon for {gameName}")

--- a/main.py
+++ b/main.py
@@ -353,7 +353,7 @@ def getImageFromStorepage():
         respone = r.json()
         
         coverImage = respone[str(gameSteamID)]["data"]["header_image"]
-        coverImageText = f"{gameName} on steam"
+        coverImageText = f"{gameName}"
         # do note this is NOT saved to disk, just in case someone ever adds an entry to the SGDB later on
         
         log(f"successfully found steam's icon for {gameName}")
@@ -430,9 +430,12 @@ def getGameImage():
                 return
     
     log("no image found in cache")
-    
+
     if gridEnabled and coverImage == "":
         getImageFromSGDB()
+
+    if appID != defaultAppID and appID != defaultLocalAppID and coverImage == "":
+        getImageFromDiscord()
         
     if steamStoreCoverartBackup and coverImage == "":
         getImageFromStorepage()
@@ -676,6 +679,36 @@ def getGameDiscordID(loops=0):
     log(f"could not find the discord game ID for {gameName}, defaulting to well, the default game ID")
     appID = defaultAppID
     return
+
+# get game's icon straight from Discord's CDN
+def getImageFromDiscord():
+    global coverImage
+    global coverImageText
+
+    log("getting icon from Discord")
+
+    try: 
+        r = makeWebRequest(f"https://discordapp.com/api/v8/applications/{appID}/rpc")
+        if r == "error":
+            return
+        
+        if r.status_code != 200:
+            error(f"status code {r.status_code} returned when requesting more info about {gameName} from Discord, ignoring")
+            coverImage = None
+            coverImageText = None
+            return
+        
+        respone = r.json()
+        
+        coverImage = f"https://cdn.discordapp.com/app-icons/{appID}/{respone["icon"]}.webp"
+        coverImageText = f"{respone["name"]}"
+        
+        log(f"successfully found Discord icon for {gameName}")
+
+    except Exception as e:
+        error(f"Exception {e} raised when trying to fetch {gameName}'s icon from Discord, ignoring")
+        coverImage = None
+        coverImageText = None
 
 # checks if any local games are running
 def getLocalPresence():


### PR DESCRIPTION
A simple implementation of fetching the exact same game icon as would end up being used when playing it natively on Windows, straight from Discord's CDN.

Since Steam Presence already uses `/api/v8/applications/detectable` to find game's `id`, it's possible to reuse that exact `id` to fetch more info about the game from `/api/v8/applications/{id}/rpc`, including a hash of the game's icon.
Then it's possible to access the actual icon from `https://cdn.discordapp.com/app-icons/{id}/{icon}.webp`

[Here's a response for Baldur's Gate 3](https://discordapp.com/api/v8/applications/1137125502985961543/rpc) and [its icon from Discord's CDN](https://cdn.discordapp.com/app-icons/1137125502985961543/3d6a6ddf065f232dc0d93af3050954ce.webp).

I've tested this with a few games and works great so far.