### PR TITLE
Embedded quotes causes errors in python 3.11 but does not in 3.13

### DIFF
--- a/main.py
+++ b/main.py
@@ -700,8 +700,8 @@ def getImageFromDiscord():
         
         respone = r.json()
         
-        coverImage = f"https://cdn.discordapp.com/app-icons/{appID}/{respone["icon"]}.webp"
-        coverImageText = f"{respone["name"]}"
+        coverImage = f"https://cdn.discordapp.com/app-icons/{appID}/{respone['icon']}.webp"
+        coverImageText = f"{respone['name']}"
         
         log(f"successfully found Discord icon for {gameName}")
 


### PR DESCRIPTION
This fixes an issue for f-strings with embedded quotes. On Python 3.11 (in Debian 12 for example), this will throw errors as below:

Successfully installed beautifulsoup4-4.12.3 certifi-2024.6.2 charset-normalizer-3.3.2 idna-3.7 psutil-6.0.0 pypresence-4.3.0 python-steamgriddb-1.0.5 requests-2.32.3 soupsieve-2.5 urllib3-2.2
.2                                                                                                                                                                                              
                                                                                                                                                                                                
```
Testing if the script works

  File "/home/psi-jack/.local/bin/steam-presence/./main.py", line 704
    coverImageText = f"{respone["name"]}"
                                 ^^^^
SyntaxError: f-string: unmatched '['
```
In python 3.13 it would work unhindered. Better compatibility is, use 'other' quotes in f-string, or not use f-string.
