### PR TITLE
Add game whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ this is what a full config file looks like; you only need to fill in the parts t
     	"game1",
     	"game2",
     	"game3"
-    ]
+    ],
+
+    "WHITELIST": []
 }
 ```
 # Steam web API
@@ -409,6 +411,18 @@ Example:
 ]
 ```
 
+# Whitelist
+
+Here you can add games that should only show up in Discord's rich presence, all games not included here will not create a rich presence object. Leave empty to have no whitelist. Please fill in the games field according to the full name of the games, these are not case sensitive.
+
+Example:
+```
+"WHITELIST" : [
+    "Hades",
+    "Deep Rock Galactic",
+    "Risk of Rain 2"
+]
+```
 
 # Python
 only tested on python3.8 and higher.

--- a/main.py
+++ b/main.py
@@ -154,7 +154,9 @@ def getConfigFile():
             "game1",
             "game2",
             "game3"
-        ]
+        ],
+
+        "WHITELIST" : []
     }
 
     if exists(f"{dirname(abspath(__file__))}/config.json"):
@@ -818,6 +820,11 @@ def setPresenceDetails():
         return
     
     currentGameBlacklisted = False
+
+    # ignore game if it is not whitelisted, case insensitive check
+    if whitelist and gameName.casefold() not in map(str.casefold, whitelist):
+        log(f"{gameName} is not in whitelist, not creating RPC object.")
+        return
     
     # if the game ID is corresponding to "a game on steam" - set the details field to be the real game name
     if appID == defaultAppID or appID == defaultLocalAppID:
@@ -990,6 +997,7 @@ def main():
     global defaultAppID
     global defaultLocalAppID
     global blacklist
+    global whitelist
     global currentGameBlacklisted
     currentGameBlacklisted = False
     
@@ -1028,6 +1036,7 @@ def main():
     doLocalGames = config["LOCAL_GAMES"]["ENABLED"]
     localGames = config["LOCAL_GAMES"]["GAMES"]
     blacklist = config["BLACKLIST"]
+    whitelist = config["WHITELIST"]
     
     steamStoreCoverartBackup = config["COVER_ART"]["USE_STEAM_STORE_FALLBACK"]
     gridEnabled = config["COVER_ART"]["STEAM_GRID_DB"]["ENABLED"]
@@ -1106,6 +1115,7 @@ def main():
         doLocalGames = config["LOCAL_GAMES"]["ENABLED"]
         localGames = config["LOCAL_GAMES"]["GAMES"]
         blacklist = config["BLACKLIST"]
+        whitelist = config["WHITELIST"]
         
         steamStoreCoverartBackup = config["COVER_ART"]["USE_STEAM_STORE_FALLBACK"]
         gridEnabled = config["COVER_ART"]["STEAM_GRID_DB"]["ENABLED"]


### PR DESCRIPTION
Opposed to the blacklist, this feature allows the user to whitelist specific games to generate a rich presence object.