### PR TITLE
Fix localGames not being detected when processes changed

### DIFF
--- a/main.py
+++ b/main.py
@@ -733,8 +733,16 @@ def getLocalPresence():
     
     try:
         # get a list of all open applications, make a list of their creation times, and their names
-        processCreationTimes = [i.create_time() for i in psutil.process_iter()]
-        processNames = [i.name().lower() for i in psutil.process_iter()]
+        processCreationTimes = []
+        processNames = []
+
+        for proc in psutil.process_iter():
+            try:
+                processCreationTimes.append(proc.create_time())
+                processNames.append(proc.name().lower())
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                # Continue instead of return when processes have updated since they were grabbed
+                continue
     except:
         return
 


### PR DESCRIPTION
When trying to detect localGames, the script would fail with an error such as:

`ERROR: [Sep 19 2025 - 09:35:40] Exception process no longer exists (pid=2279482) raised`
 
The solution is to ignore the individual errors and proceed through the list of remaining processes. 
Additionally, now processCreationTime and processName are retrieved simultaneously, ensuring their indices match.