### PR TITLE
bump main.py "currentVersion" from "v1.12.1" to the latest release tag "v1.12.2"

### DIFF
--- a/main.py
+++ b/main.py
@@ -991,7 +991,7 @@ def checkForUpdate():
 def main():
     global currentVersion
     # this always has to match the newest release tag
-    currentVersion = "v1.12.1"
+    currentVersion = "v1.12.2"
     
     # check if there's any updates for the program
     checkForUpdate()


### PR DESCRIPTION
changed bc this is causing unnecessary warnings, even if the repo is the latest possible the app still was giving warning to update it

fix this warning:
<img width="1653" height="183" alt="image" src="https://github.com/user-attachments/assets/2928c1a9-dd16-49ab-b62b-002a2e77c488" />
