### PR TITLE
fix venv mkdir error "if already exists"

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -27,7 +27,7 @@ for file in games.txt icons.txt customGameIDs.json; do
 done
 
 echo "Setting up virtual environment"
-mkdir venv
+mkdir -p venv
 cd venv
 python3 -m venv .
 ./bin/python -m pip install --upgrade pip wheel


### PR DESCRIPTION
this fix changes the [installer.sh](https://github.com/JustTemmie/steam-presence/blob/main/installer.sh) to remove  the error log that happens when the user rerun the script, that is a minor error, but for people that is not in the tech world, seeing an "error" in the terminal may be scary

this pr code will remove the "venv directory already exists" warning with the "-p" flag to mkdir:
```bash
mkdir -p venv
```

there is other method that can be more robust, like:
removing the venv directory if exist, and create an new one, to unsure that everything is nicely setted
```bash
if [ -d "$PWD/venv" ]; then
	rm -r venv
fi
mkdir venv
```