### PR TITLE
Use local game name as application name

### DIFF
--- a/main.py
+++ b/main.py
@@ -816,6 +816,7 @@ def setPresenceDetails():
     global startTime
     global currentGameBlacklisted
     
+    name = None
     details = None
     state = None
     buttons = None
@@ -836,7 +837,7 @@ def setPresenceDetails():
     
     # if the game ID is corresponding to "a game on steam" - set the details field to be the real game name
     if appID == defaultAppID or appID == defaultLocalAppID:
-        details = gameName
+        name = gameName
     
     if activeRichPresence != gameRichPresence:
         if gameRichPresence != "":
@@ -880,6 +881,7 @@ def setPresenceDetails():
     
     try:
         RPC.update(
+            name = name,
             details = details, state = state,
             start = startTime,
             large_image = coverImage, large_text = coverImageText,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-steamgriddb
-pypresence == 4.3.0
+pypresence
 beautifulsoup4
 requests
 psutil


### PR DESCRIPTION
Since pypresence 4.6.0, `update()` accepts a `name` parameter for RPC, letting users set custom game names unreliant on the Default Application ID/Name

https://github.com/qwertyquerty/pypresence/releases/tag/v4.6.0

<img width="277" height="121" alt="image" src="https://github.com/user-attachments/assets/3a830bc1-9e02-40eb-8299-980521b3034d" />
