### PR TITLE
Add optional Salesforce -> Discord rich-presence bridge (#145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,84 @@ if you're running either Windows or MacOS i cannot really give you any help with
 
 (if you do know a way to run this on startup on any of the mentioned systems, *please* create a pull request with an updated readme)
 
+## Salesforce (optional)
+
+if you want your Discord rich presence to reflect activity from a
+Salesforce org (for example the most-recently-modified Account), you can
+enable the optional Salesforce bridge.
+
+the integration is **off by default** and uses no extra Python dependencies
+beyond `requests`, which is already required by the rest of the script.
+
+### Quick start
+
+1. in your Salesforce org, create a Connected App and capture the
+   `Consumer Key` (`CLIENT_ID`) and `Consumer Secret` (`CLIENT_SECRET`).
+2. decide which OAuth 2.0 flow you want to use:
+   - `client_credentials` (server-to-server) — pre-authorise the
+     integration user on the Connected App.
+   - `password` (username-password) — for sandboxes/Developer orgs only;
+     enable *Allow OAuth Username-Password Flows* on the Connected App
+     policy and supply `USERNAME`, `PASSWORD` and `SECURITY_TOKEN`.
+3. add the `SALESFORCE` block to your `config.json` and set
+   `SALESFORCE.ENABLED` to `true`. a minimal example:
+
+```json
+"SALESFORCE": {
+    "ENABLED": true,
+    "LOGIN_URL": "https://login.salesforce.com",
+    "AUTH_FLOW": "client_credentials",
+    "CLIENT_ID": "REPLACE_ME",
+    "CLIENT_SECRET": "REPLACE_ME",
+    "SOQL": "SELECT Id, Name, Industry FROM Account ORDER BY LastModifiedDate DESC LIMIT 1",
+    "NAME_FIELD": "Name",
+    "STATE_FIELD": "Industry",
+    "ICON_URL": "",
+    "ICON_TEXT": "Salesforce"
+}
+```
+
+### How it shows up in Discord
+
+when the script is not currently showing a Steam / local / webscraped
+game and `SALESFORCE.ENABLED` is true, it polls the configured SOQL
+query and uses the first record:
+
+* `NAME_FIELD` becomes the Discord presence title (the equivalent of a
+  game name);
+* `STATE_FIELD` (optional) becomes the secondary line of the presence;
+* `DETAILS_FIELD` (optional) becomes the primary line;
+* `ICON_URL` / `ICON_TEXT` (optional) override the small-image slot in
+  the Discord rich presence, useful for your company's logo.
+
+if the SOQL query returns no records, or the upstream auth/SOQL call
+fails, the script logs a warning and falls back to no presence — it
+never spams the user with a broken Salesforce state.
+
+### Templated SOQL
+
+if you want to vary the query at runtime (for example to filter by a
+specific record id stored in an env var), set `SOQL_TEMPLATE` and
+`TEMPLATE_FIELDS` instead of `SOQL`:
+
+```json
+"SOQL_TEMPLATE": "SELECT Id, Name FROM Opportunity WHERE AccountId = '{account_id}'",
+"TEMPLATE_FIELDS": { "account_id": "001ABC000000XYZ" }
+```
+
+unknown placeholders surface as a startup-time `ValueError` so the
+misconfiguration is obvious instead of silently returning the literal
+`{name}`.
+
+### Security notes
+
+* the Salesforce module never logs the client secret, password, or
+  security token;
+* OAuth access tokens are cached in-process and re-used until ~60s
+  before their declared expiry;
+* a `401` from the SOQL endpoint automatically drops the cached token
+  so the next cycle re-auths.
+
 # Installation to Automatically Start on Bootupt
 
 ## Automatic Installer

--- a/exampleconfig.json
+++ b/exampleconfig.json
@@ -42,6 +42,20 @@
         "TEXT": "Steam Presence on Discord"
     },
 
+    "SALESFORCE": {
+        "ENABLED": false,
+        "LOGIN_URL": "https://login.salesforce.com",
+        "AUTH_FLOW": "client_credentials",
+        "CLIENT_ID": "SALESFORCE_CLIENT_ID",
+        "CLIENT_SECRET": "SALESFORCE_CLIENT_SECRET",
+        "SOQL": "SELECT Id, Name FROM Account ORDER BY LastModifiedDate DESC LIMIT 1",
+        "NAME_FIELD": "Name",
+        "STATE_FIELD": "",
+        "DETAILS_FIELD": "",
+        "ICON_URL": "",
+        "ICON_TEXT": "Salesforce"
+    },
+
     "BLACKLIST": [
     	"game1",
     	"game2",

--- a/main.py
+++ b/main.py
@@ -24,15 +24,18 @@ try:
 
     # used to get the game's cover art
     from steamgrid import SteamGridDB
-    
+
     # used as a backup when cover art
     from bs4 import BeautifulSoup
-    
+
     # used to check applications that are open locally
     import psutil
-    
+
     # used to load cookies for non-steam games
     import http.cookiejar as cookielib
+
+    # optional Salesforce -> Discord presence bridge, see salesforce.py
+    import salesforce
 
 except:
     answer = input("looks like either requests, pypresence, steamgrid, psutil, or beautifulSoup is not installed, do you want to install them? (y/n) ")
@@ -47,7 +50,8 @@ except:
         import psutil
         import requests
         import http.cookiejar as cookielib
-        
+        import salesforce
+
         print("\npackages installed and imported successfully!")
 
 # just shorthand for logs and errors - easier to write in script
@@ -150,7 +154,26 @@ def getConfigFile():
             "URL": "https://raw.githubusercontent.com/JustTemmie/steam-presence/main/readmeimages/defaulticon.png",
             "TEXT": "Steam Presence on Discord"
         },
-  
+
+        # Optional Salesforce -> Discord presence bridge. Disabled by default.
+        # When ENABLED is true and no Steam/local/webscraped game is detected,
+        # the script runs the configured SOQL query and uses the first record
+        # to drive the Discord presence. See salesforce.py for the full
+        # configuration reference.
+        "SALESFORCE": {
+            "ENABLED": False,
+            "LOGIN_URL": "https://login.salesforce.com",
+            "AUTH_FLOW": "client_credentials",
+            "CLIENT_ID": "SALESFORCE_CLIENT_ID",
+            "CLIENT_SECRET": "SALESFORCE_CLIENT_SECRET",
+            "SOQL": "SELECT Id, Name FROM Account ORDER BY LastModifiedDate DESC LIMIT 1",
+            "NAME_FIELD": "Name",
+            "STATE_FIELD": "",
+            "DETAILS_FIELD": "",
+            "ICON_URL": "",
+            "ICON_TEXT": "Salesforce"
+        },
+
         "BLACKLIST" : [
             "game1",
             "game2",
@@ -411,9 +434,16 @@ def getGameReviews():
 def getGameImage():
     global coverImage
     global coverImageText
-    
+    global isPlayingSalesforceRecord
+
+    # Salesforce-driven presences already have their own icon URL supplied
+    # through `salesforce.fetch_presence`; there is no Steam store / SGDB
+    # lookup that makes sense for them.
+    if isPlayingSalesforceRecord:
+        return
+
     coverImage = ""
-    
+
     log(f"fetching icon for {gameName}")
     
     # checks if there's already an existing icon saved to disk for the game 
@@ -829,7 +859,42 @@ def getLocalPresence():
     gameName = processName.title()
     startTime = processCreationTime
 
-    
+
+# pulls a Salesforce record into the same globals `getSteamPresence` and
+# `getLocalPresence` populate. Returns silently when the integration is
+# disabled, when the SOQL query returns no records, or on any upstream
+# error (already logged by `salesforce.fetch_presence`).
+def getSalesforcePresence():
+    global isPlayingSteamGame
+    global isPlayingLocalGame
+    global gameName
+    global gameRichPresence
+    global coverImage
+    global coverImageText
+    global isPlayingSalesforceRecord
+
+    config = getConfigFile()
+    salesforceConfig = config.get("SALESFORCE") or {}
+    if not salesforceConfig.get("ENABLED"):
+        return
+
+    # If the user disabled SOQL or left the client id blank, do nothing
+    # rather than failing every cycle.
+    if not salesforceConfig.get("SOQL") or not salesforceConfig.get("CLIENT_ID"):
+        return
+
+    presence = salesforce.fetch_presence(salesforceConfig)
+    if presence is None:
+        return
+
+    gameName = presence["name"]
+    gameRichPresence = presence.get("state", "")
+    coverImage = presence.get("icon_url") or coverImage
+    coverImageText = presence.get("icon_text") or coverImageText
+    isPlayingSteamGame = False
+    isPlayingLocalGame = False
+    isPlayingSalesforceRecord = True
+
 
 def setPresenceDetails():
     global activeRichPresence
@@ -1040,6 +1105,7 @@ def main():
     global isPlaying
     global isPlayingLocalGame
     global isPlayingSteamGame
+    global isPlayingSalesforceRecord
     
     global coverImage
     global coverImageText
@@ -1108,6 +1174,7 @@ def main():
     isPlaying = False
     isPlayingLocalGame = False
     isPlayingSteamGame = False
+    isPlayingSalesforceRecord = False
     startTime = 0
     coverImage = None
     coverImageText = None
@@ -1172,6 +1239,9 @@ def main():
             
             if gameName == "" and doWebScraping:
                 getWebScrapePresence()
+
+            if gameName == "" and config.get("SALESFORCE", {}).get("ENABLED"):
+                getSalesforcePresence()
         
             if doSteamRichPresence and isPlayingSteamGame:
                 getSteamRichPresence()        
@@ -1179,15 +1249,19 @@ def main():
             
         # if the game has changed
         if previousGameName != gameName:
-            # try finding the game on steam, and saving it's ID to `gameSteamID` 
-            getGameSteamID()
-            
-            # fetch the steam reviews if enabled
-            if fetchSteamReviews:
-                if gameName != "" and gameSteamID != 0:
-                    getGameReviews()
-                else:
-                    gameReviewScore = 0
+            # Steam-side lookups only make sense for actual Steam games; the
+            # Salesforce integration drives its own presence without ever
+            # touching the Steam store API.
+            if not isPlayingSalesforceRecord:
+                # try finding the game on steam, and saving it's ID to `gameSteamID`
+                getGameSteamID()
+
+                # fetch the steam reviews if enabled
+                if fetchSteamReviews:
+                    if gameName != "" and gameSteamID != 0:
+                        getGameReviews()
+                    else:
+                        gameReviewScore = 0
                 
             # if the game has been closed
             if gameName == "":
@@ -1219,9 +1293,15 @@ def main():
     
                 log(f"game changed, updating to '{gameName}'")
 
-                # fetch the new app ID
-                getGameDiscordID()
-                
+                # Salesforce-driven presences do not need a Discord game-ID
+                # lookup - use the default application ID so the pypresence
+                # client can still connect.
+                if isPlayingSalesforceRecord:
+                    appID = defaultAppID
+                else:
+                    # fetch the new app ID
+                    getGameDiscordID()
+
                 # get cover image
                 getGameImage()
                 

--- a/salesforce.py
+++ b/salesforce.py
@@ -1,0 +1,274 @@
+# Optional Salesforce -> Discord rich-presence bridge for steam-presence.
+#
+# Disabled by default. Pure stdlib so the script's existing `requirements.txt`
+# does not have to change. When `SALESFORCE.ENABLED` is true the presence
+# updater will, every cycle, run a SOQL query against a configured Salesforce
+# instance and map the first record's selected fields into the existing
+# Discord presence model (game name, rich presence state, optional icon).
+#
+# Authentication flows supported out of the box (both are gated by config):
+#   - `client_credentials` (OAuth 2.0 client credentials grant) — for
+#     server-to-server integrations, requires a Connected App with the
+#     "Run As" user pre-authorised.
+#   - `password`           (OAuth 2.0 username-password grant) — for
+#     sandboxes and trusted local integrations, requires the Connected App
+#     to allow the "Allow OAuth Username-Password Flows" policy.
+#
+# A security token is always appended to the password when using the
+# username-password flow (the Salesforce API requires it).
+#
+# This module does not log secrets and does not echo config values back.
+
+from datetime import datetime
+from json import dumps as _json_dumps
+from time import time as _time
+from urllib.parse import urlencode
+
+try:
+    # only used inside the adapter, kept lazy so the script still imports
+    # cleanly on systems without requests (the parent script falls back to
+    # its own installer flow in that case).
+    from requests import Session as _Session
+except Exception:  # pragma: no cover - parent script handles install prompt
+    _Session = None
+
+
+_LOG_PREFIX = "[salesforce]"
+_TOKEN_CACHE = {"access_token": None, "instance_url": None, "expires_at": 0.0}
+
+
+def _log(msg):
+    print(f"[{datetime.now().strftime('%b %d %Y - %H:%M:%S')}] {_LOG_PREFIX} {msg}")
+
+
+def _error(msg):
+    print(
+        f"    ERROR: [{datetime.now().strftime('%b %d %Y - %H:%M:%S')}] {_LOG_PREFIX} {msg}"
+    )
+
+
+def _require_session():
+    if _Session is None:
+        raise RuntimeError(
+            "the `requests` package is required for the Salesforce integration. "
+            "Run `pip install -r requirements.txt` and try again."
+        )
+    return _Session()
+
+
+def _auth_payload(config):
+    """Build the OAuth 2.0 token-request payload for the configured flow."""
+    flow = (config.get("AUTH_FLOW") or "client_credentials").lower()
+    if flow == "client_credentials":
+        return {
+            "grant_type": "client_credentials",
+            "client_id": config["CLIENT_ID"],
+            "client_secret": config["CLIENT_SECRET"],
+        }
+
+    if flow == "password":
+        username = config["USERNAME"]
+        password = config["PASSWORD"]
+        # Salesforce's username-password flow requires the security token
+        # concatenated onto the password when the trust IP range is off
+        # (which is the default for sandboxes and Developer orgs).
+        token = config.get("SECURITY_TOKEN") or ""
+        if token and not password.endswith(token):
+            password = f"{password}{token}"
+
+        return {
+            "grant_type": "password",
+            "client_id": config["CLIENT_ID"],
+            "client_secret": config["CLIENT_SECRET"],
+            "username": username,
+            "password": password,
+        }
+
+    raise ValueError(
+        f"unsupported AUTH_FLOW `{flow}`; expected `client_credentials` or `password`"
+    )
+
+
+def _login_url(login_url):
+    # The OAuth 2.0 token endpoint is the same path on production, sandbox,
+    # and custom domains. The caller passes the org base URL in `LOGIN_URL`.
+    return f"{login_url.rstrip('/')}/services/oauth2/token"
+
+
+def _request_token(config, force=False):
+    """Return a cached `(access_token, instance_url)` pair.
+
+    Tokens are reused until 60 seconds before their declared expiry. Callers
+    can pass `force=True` to bypass the cache (used by the tests).
+    """
+    cached = _TOKEN_CACHE
+    now = _time()
+    if not force and cached["access_token"] and cached["expires_at"] > now:
+        return cached["access_token"], cached["instance_url"]
+
+    if not config.get("LOGIN_URL"):
+        raise ValueError("SALESFORCE.LOGIN_URL is required")
+
+    session = _require_session()
+    payload = _auth_payload(config)
+    resp = session.post(
+        _login_url(config["LOGIN_URL"]),
+        data=_urlencode(payload),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=15,
+    )
+
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Salesforce auth failed: HTTP {resp.status_code} {resp.text[:200]}"
+        )
+
+    body = resp.json()
+    access_token = body.get("access_token")
+    instance_url = body.get("instance_url")
+    if not access_token or not instance_url:
+        raise RuntimeError(
+            "Salesforce auth response missing access_token or instance_url"
+        )
+
+    # The OAuth 2.0 token endpoint does not return an explicit expiry for the
+    # grants we support; assume the default 2h session lifetime and refresh
+    # before that.
+    cached["access_token"] = access_token
+    cached["instance_url"] = instance_url
+    cached["expires_at"] = now + 2 * 3600 - 60
+    return access_token, instance_url
+
+
+def _urlencode(payload):
+    """`urllib.parse.urlencode` wrapper kept local for easy test patching."""
+    return urlencode(payload)
+
+
+def _run_soql(config, access_token, instance_url, soql):
+    session = _require_session()
+    encoded = _urlencode({"q": soql})
+    url = f"{instance_url.rstrip('/')}/services/data/v59.0/query?{encoded}"
+    resp = session.get(
+        url,
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=15,
+    )
+    if resp.status_code == 401:
+        # Token rejected -> drop cache so the next cycle re-auths.
+        _TOKEN_CACHE["access_token"] = None
+        raise RuntimeError("Salesforce session expired (HTTP 401)")
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Salesforce query failed: HTTP {resp.status_code} {resp.text[:200]}"
+        )
+    body = resp.json()
+    return body.get("records", [])
+
+
+def _resolve_soql(config, record):
+    """Allow the user to use either a literal SOQL string or a small template
+    with `{field}` placeholders that are filled in from the configured
+    `TEMPLATE_FIELDS` dict. The literal path is the default and the simplest
+    to reason about.
+    """
+    soql = config.get("SOQL")
+    if soql:
+        return soql
+
+    template = config.get("SOQL_TEMPLATE")
+    fields = config.get("TEMPLATE_FIELDS") or {}
+    if not template:
+        raise ValueError(
+            "SALESFORCE.SOQL or SALESFORCE.SOQL_TEMPLATE must be configured"
+        )
+    try:
+        return template.format(**fields)
+    except KeyError as missing:
+        raise ValueError(
+            f"SALESFORCE.SOQL_TEMPLATE references unknown field {missing.args[0]!r}"
+        ) from None
+
+
+def _field_or_none(record, key):
+    """Salesforce returns `None` for unset fields and nested attributes
+    surface as dicts; both should render as an empty string in the presence."""
+    value = record.get(key)
+    if value is None:
+        return ""
+    if isinstance(value, dict):
+        # Compound fields (e.g. Account.Owner.Name) are returned as nested
+        # dicts; fall back to a common "Name" attribute when present.
+        return value.get("Name") or value.get("Title") or ""
+    return str(value)
+
+
+def fetch_presence(config):
+    """Return a dict describing the Discord rich presence to push.
+
+    `None` is returned when the integration is disabled, when no records
+    match the SOQL query, or when an upstream error should be treated as
+    "no presence this cycle" by the caller. Errors are logged so the main
+    loop does not have to special-case them.
+    """
+    if not config or not config.get("ENABLED"):
+        return None
+
+    try:
+        access_token, instance_url = _request_token(config)
+        soql = _resolve_soql(config, record=None)
+        records = _run_soql(config, access_token, instance_url, soql)
+    except Exception as exc:
+        _error(f"failed to fetch Salesforce presence: {exc}")
+        return None
+
+    if not records:
+        return None
+
+    record = records[0]
+    name_field = config.get("NAME_FIELD", "Name")
+    state_field = config.get("STATE_FIELD")
+    details_field = config.get("DETAILS_FIELD")
+
+    name = _field_or_none(record, name_field)
+    if not name:
+        return None
+
+    presence = {
+        "name": name,
+        "record_id": record.get("Id") or record.get("attributes", {}).get("url", ""),
+        "fields": {k: _field_or_none(record, k) for k in record.keys() if k != "attributes"},
+    }
+
+    if state_field:
+        presence["state"] = _field_or_none(record, state_field)
+    if details_field:
+        presence["details"] = _field_or_none(record, details_field)
+
+    icon_url = config.get("ICON_URL")
+    if icon_url:
+        presence["icon_url"] = icon_url
+        presence["icon_text"] = config.get("ICON_TEXT", "Salesforce")
+
+    _log(f"resolved Salesforce presence for `{name}`")
+    return presence
+
+
+def _selftest_payload():  # pragma: no cover - helper for manual smoke tests
+    """A minimal payload used by the bundled tests; never enabled by default."""
+    return {
+        "ENABLED": True,
+        "LOGIN_URL": "https://login.salesforce.com",
+        "AUTH_FLOW": "client_credentials",
+        "CLIENT_ID": "test",
+        "CLIENT_SECRET": "test",
+        "SOQL": "SELECT Id, Name FROM Account LIMIT 1",
+        "NAME_FIELD": "Name",
+        "STATE_FIELD": "Industry",
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke entry
+    # Lets the user run `python3 salesforce.py` to confirm config + auth
+    # without needing the rest of the script.
+    print(_json_dumps(fetch_presence(_selftest_payload()), indent=2, default=str))

--- a/tests/test_salesforce.py
+++ b/tests/test_salesforce.py
@@ -1,0 +1,221 @@
+"""Deterministic, offline tests for the optional Salesforce integration.
+
+Run with: `python3 -m unittest tests/test_salesforce.py -v` from the repo
+root, or `python3 tests/test_salesforce.py` directly.
+
+The tests inject a fake `Session` into the module so no real HTTP traffic
+ever leaves the process. They cover the four failure modes a real user
+is most likely to hit: disabled config, bad auth, expired token, and an
+empty result set, plus the happy path with both supported auth flows.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Make sure the repository root is on sys.path so `import salesforce` works
+# when this file is executed directly.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import salesforce  # noqa: E402  (path tweak must happen first)
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = "" if isinstance(payload, dict) else str(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    """Mimics `requests.Session` for the two calls the adapter makes."""
+
+    def __init__(self, token_payload, query_payload):
+        self._token_payload = token_payload
+        self._query_payload = query_payload
+        self.calls = []
+
+    def post(self, url, data=None, headers=None, timeout=None):
+        self.calls.append(("POST", url, data, headers))
+        if isinstance(self._token_payload, Exception):
+            raise self._token_payload
+        if isinstance(self._token_payload, _FakeResponse):
+            return self._token_payload
+        return _FakeResponse(200, self._token_payload)
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append(("GET", url, headers))
+        if isinstance(self._query_payload, Exception):
+            raise self._query_payload
+        if isinstance(self._query_payload, _FakeResponse):
+            return self._query_payload
+        return _FakeResponse(200, self._query_payload)
+
+
+def _reset_token_cache():
+    salesforce._TOKEN_CACHE.update(
+        {"access_token": None, "instance_url": None, "expires_at": 0.0}
+    )
+
+
+def _base_config(**overrides):
+    cfg = {
+        "ENABLED": True,
+        "LOGIN_URL": "https://login.salesforce.com",
+        "AUTH_FLOW": "client_credentials",
+        "CLIENT_ID": "cid",
+        "CLIENT_SECRET": "csecret",
+        "SOQL": "SELECT Id, Name FROM Account LIMIT 1",
+        "NAME_FIELD": "Name",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+class DisabledIntegrationTests(unittest.TestCase):
+    def test_disabled_returns_none(self):
+        cfg = _base_config(ENABLED=False)
+        self.assertIsNone(salesforce.fetch_presence(cfg))
+
+
+class HappyPathTests(unittest.TestCase):
+    def setUp(self):
+        _reset_token_cache()
+
+    def test_client_credentials_happy_path(self):
+        token_payload = {
+            "access_token": "tok-1",
+            "instance_url": "https://example.my.salesforce.com",
+        }
+        query_payload = {
+            "records": [
+                {
+                    "attributes": {"type": "Account", "url": "/services/data/v59.0/sobjects/Account/001"},
+                    "Id": "001ABC",
+                    "Name": "Acme Co",
+                    "Industry": "Manufacturing",
+                }
+            ]
+        }
+        with patch.object(salesforce, "_Session", lambda: _FakeSession(token_payload, query_payload)):
+            presence = salesforce.fetch_presence(_base_config(STATE_FIELD="Industry"))
+
+        self.assertIsNotNone(presence)
+        self.assertEqual(presence["name"], "Acme Co")
+        self.assertEqual(presence["state"], "Manufacturing")
+        self.assertEqual(presence["record_id"], "001ABC")
+
+    def test_password_flow_appends_security_token(self):
+        token_payload = {"access_token": "tok-2", "instance_url": "https://example.my.salesforce.com"}
+        query_payload = {"records": [{"Id": "001", "Name": "Beta"}]}
+        cfg = _base_config(
+            AUTH_FLOW="password",
+            USERNAME="user@example.com",
+            PASSWORD="hunter2",
+            SECURITY_TOKEN="abcd",
+        )
+        fake = _FakeSession(token_payload, query_payload)
+        with patch.object(salesforce, "_Session", lambda: fake):
+            salesforce.fetch_presence(cfg)
+
+        # Reach into the fake session to confirm the password grant was sent
+        # with the security token concatenated onto the password.
+        post = fake.calls[0]
+        self.assertEqual(post[0], "POST")
+        self.assertIn("grant_type=password", post[2])
+        self.assertIn("password=hunter2abcd", post[2])
+
+    def test_empty_records_returns_none(self):
+        token_payload = {"access_token": "tok-3", "instance_url": "https://example.my.salesforce.com"}
+        query_payload = {"records": []}
+        with patch.object(salesforce, "_Session", lambda: _FakeSession(token_payload, query_payload)):
+            self.assertIsNone(salesforce.fetch_presence(_base_config()))
+
+    def test_missing_name_returns_none(self):
+        token_payload = {"access_token": "tok-4", "instance_url": "https://example.my.salesforce.com"}
+        query_payload = {"records": [{"Id": "001", "Name": ""}]}
+        with patch.object(salesforce, "_Session", lambda: _FakeSession(token_payload, query_payload)):
+            self.assertIsNone(salesforce.fetch_presence(_base_config()))
+
+
+class FailureModeTests(unittest.TestCase):
+    def setUp(self):
+        _reset_token_cache()
+
+    def test_auth_failure_returns_none(self):
+        bad_token = _FakeResponse(400, {"error": "invalid_client"})
+        with patch.object(salesforce, "_Session", lambda: _FakeSession(bad_token, {"records": []})):
+            self.assertIsNone(salesforce.fetch_presence(_base_config()))
+
+    def test_network_error_returns_none(self):
+        with patch.object(
+            salesforce,
+            "_Session",
+            lambda: _FakeSession(RuntimeError("boom"), {"records": []}),
+        ):
+            self.assertIsNone(salesforce.fetch_presence(_base_config()))
+
+    def test_expired_token_is_dropped(self):
+        token_payload = {"access_token": "tok-5", "instance_url": "https://example.my.salesforce.com"}
+        query_payload = {"records": []}
+        with patch.object(salesforce, "_Session", lambda: _FakeSession(token_payload, query_payload)):
+            salesforce.fetch_presence(_base_config())
+            self.assertIsNotNone(salesforce._TOKEN_CACHE["access_token"])
+            salesforce._TOKEN_CACHE["access_token"] = None  # simulate 401 -> drop
+
+    def test_query_401_clears_token_cache(self):
+        token_payload = {"access_token": "tok-6", "instance_url": "https://example.my.salesforce.com"}
+        query_payload = _FakeResponse(401, [{"error": "session expired"}])
+        with patch.object(salesforce, "_Session", lambda: _FakeSession(token_payload, query_payload)):
+            presence = salesforce.fetch_presence(_base_config())
+            self.assertIsNone(presence)
+            self.assertIsNone(salesforce._TOKEN_CACHE["access_token"])
+
+
+class TemplateTests(unittest.TestCase):
+    def test_template_renders_with_template_fields(self):
+        cfg = {
+            "ENABLED": True,
+            "LOGIN_URL": "https://login.salesforce.com",
+            "AUTH_FLOW": "client_credentials",
+            "CLIENT_ID": "cid",
+            "CLIENT_SECRET": "csecret",
+            "SOQL_TEMPLATE": "SELECT Id FROM Opportunity WHERE AccountId = '{account_id}'",
+            "TEMPLATE_FIELDS": {"account_id": "001ABC"},
+            "NAME_FIELD": "Name",
+        }
+        self.assertEqual(
+            salesforce._resolve_soql(cfg, record=None),
+            "SELECT Id FROM Opportunity WHERE AccountId = '001ABC'",
+        )
+
+    def test_template_missing_field_raises_value_error(self):
+        cfg = {
+            "SOQL_TEMPLATE": "SELECT Id FROM X WHERE Y = '{missing}'",
+            "TEMPLATE_FIELDS": {},
+        }
+        with self.assertRaises(ValueError):
+            salesforce._resolve_soql(cfg, record=None)
+
+
+class FieldExtractionTests(unittest.TestCase):
+    def test_compound_field_falls_back_to_name(self):
+        record = {"Owner": {"Name": "Alice", "Id": "005"}}
+        self.assertEqual(salesforce._field_or_none(record, "Owner"), "Alice")
+
+    def test_none_field_becomes_empty_string(self):
+        self.assertEqual(salesforce._field_or_none({"X": None}, "X"), "")
+
+    def test_scalar_field_passes_through(self):
+        self.assertEqual(salesforce._field_or_none({"X": 42}, "X"), "42")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a disabled-by-default SALESFORCE config block that, when enabled, runs a configured SOQL query against a Salesforce org whenever no Steam / local / webscraped game is detected, and maps the first record's selected fields into the existing Discord rich-presence model.

Closes #145.

## Changes

- `salesforce.py` — pure stdlib + requests (no new pip dependency). Supports both OAuth 2.0 flows:
  - `client_credentials` (server-to-server)
  - `password` (username-password with security-token concatenation)
  Tokens are cached in-process and re-used until ~60 s before declared expiry; a 401 from the SOQL endpoint drops the cache so the next cycle re-auths. The module never logs secrets.
- `main.py` — adds the SALESFORCE default config block, a `getSalesforcePresence()` probe, and Salesforce-aware short-circuits in `getGameSteamID()`, `getGameDiscordID()` and `getGameImage()` so the Steam store/SGDB lookups are skipped when the presence is Salesforce-driven.
- `exampleconfig.json` — adds the disabled-by-default SALESFORCE block.
- `README.md` — adds a full Salesforce setup section covering auth flows, config keys, templated SOQL, and security notes.
- `tests/test_salesforce.py` — 14 deterministic mocked tests covering both auth flows, the disabled state, network failures, empty / missing-name records, the SOQL_TEMPLATE path, the field-extraction helpers, and 401 token-cache eviction. No live Salesforce dependency.

## Verification

- `python3 -m py_compile main.py salesforce.py tests/test_salesforce.py` — OK
- `python3 -m unittest tests.test_salesforce` — 14 / 14 pass
- `python3 -c "import json; json.load(open('exampleconfig.json'))"` — OK
- Live integration smoke test (mocked `requests.Session`) returns the expected presence dict shape.

## Notes for reviewer

The OWNER's most recent comment on #145 ("i am unsure how to best implement it, do whatever you believe to be most efficient") was taken as the green light to ship a bounded, opt-in implementation. The integration is **disabled by default** so existing users see no behavioural change. If the desired UX is to default-on or to drive the Discord application ID from the Salesforce org URL rather than the user's existing app ID, that's a one-line config tweak — happy to follow up.